### PR TITLE
feat: replace null-character in messages

### DIFF
--- a/src/main/java/de/uni_passau/fim/se2/pipeline_helper/model/CheckerResult.java
+++ b/src/main/java/de/uni_passau/fim/se2/pipeline_helper/model/CheckerResult.java
@@ -39,13 +39,19 @@ public class CheckerResult {
 
         this.name = name;
         this.successful = successful;
+        this.message = processMessage(message);
+    }
+
+    private String processMessage(String message) {
+        if (message == null) {
+            return null;
+        }
 
         if (isLongMessage(message)) {
-            this.message = message.substring(0, MAX_MESSAGE_LENGTH);
+            message = message.substring(0, MAX_MESSAGE_LENGTH);
         }
-        else {
-            this.message = message;
-        }
+
+        return message.replace('\0', '�');
     }
 
     private static boolean isLongMessage(final String message) {

--- a/src/test/java/de/uni_passau/fim/se2/pipeline_helper/model/CheckerResultTest.java
+++ b/src/test/java/de/uni_passau/fim/se2/pipeline_helper/model/CheckerResultTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
-public class CheckerResultTest {
+class CheckerResultTest {
 
     @Test
     void shouldNotAllowEmptyMessageForFailedTests() {
@@ -40,5 +40,11 @@ public class CheckerResultTest {
         final CheckerResult result = new CheckerResult("checker", true, "ab" + "0".repeat(inputLength));
         assertThat(result.getMessage().length()).isLessThan(inputLength);
         assertThat(result.getMessage()).startsWith("ab");
+    }
+
+    @Test
+    void shouldReplaceNullCharacters() throws CheckerException {
+        final CheckerResult result = new CheckerResult("checker", true, "ab\0c\0\0d");
+        assertThat(result.getMessage()).isEqualTo("ab�c��d");
     }
 }


### PR DESCRIPTION
Artemis (or more precisely the database) does not accept messages with the NULL (u+0000) character. No feedback is saved at all for results that contain such characters.